### PR TITLE
Add Express server for real-time games

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "chess.js": "^1.1.0",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5",
     "react": "^19.0.0",
     "react-chessboard": "^4.7.2",
     "react-dom": "^19.0.0"

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import { createServer } from 'http';
+import { Server as SocketServer } from 'socket.io';
+import { randomUUID } from 'crypto';
+
+const app = express();
+const httpServer = createServer(app);
+const io = new SocketServer(httpServer, {
+  cors: {
+    origin: '*',
+  },
+});
+
+const games = {};
+
+app.use(express.json());
+
+app.post('/game/create', (req, res) => {
+  const gameId = randomUUID();
+  games[gameId] = { players: [] };
+  res.json({ gameId });
+});
+
+app.post('/game/join/:gameId', (req, res) => {
+  const { gameId } = req.params;
+  if (!games[gameId]) {
+    return res.status(404).json({ error: 'Game not found' });
+  }
+  res.json({ message: 'Joined', gameId });
+});
+
+io.on('connection', (socket) => {
+  socket.on('joinGame', (gameId) => {
+    if (games[gameId]) {
+      socket.join(gameId);
+    }
+  });
+
+  socket.on('move', ({ gameId, move }) => {
+    if (games[gameId]) {
+      socket.to(gameId).emit('move', move);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+httpServer.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- initialize an Express server under `server/`
- include `socket.io` for real-time communication
- provide routes to create and join games
- add script `npm run server`
- add express and socket.io dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_684c15194afc8320a4edd85fc928f303